### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -19,6 +19,7 @@
     <description lang="en">Watch movie trailers for upcoming, new and classic films.</description>
     <platform>all</platform>
 	<language>en</language>
+	<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
 	<website>https://code.google.com/p/plugin</website>
 	<source>https://github.com/stacked/plugin.video.trailer.addict</source>
 	<forum>http://forum.xbmc.org/showthread.php?tid=53821</forum>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
